### PR TITLE
docs: aktualizuj status branch protection - włączone

### DIFF
--- a/docs/BRANCH_PROTECTION_SETUP.md
+++ b/docs/BRANCH_PROTECTION_SETUP.md
@@ -190,6 +190,18 @@ git reset --hard HEAD~1
 ---
 
 **Date:** 24 Listopada 2025  
-**Status:** ⏳ Awaiting manual setup  
-**Priority:** 🔴 HIGH
+**Status:** ✅ **AKTYWNE** - Branch protection włączone dla `main`  
+**Priority:** ✅ COMPLETED
+
+## ✅ Aktualny Status (2025-11-24)
+
+Branch protection zostało **pomyślnie włączone** dla gałęzi `main`:
+
+- ✅ **Require pull request reviews** - Wymagana 1 recenzja przed merge
+- ✅ **Enforce for admins** - Dotyczy również właściciela repo
+- ✅ **Block force pushes** - Zabronione force push
+- ✅ **Block deletions** - Zabronione usuwanie brancha
+- ✅ **Dismiss stale reviews** - Automatyczne odrzucanie przestarzałych recenzji
+
+**Ważne:** Teraz nawet Ty (właściciel) musisz tworzyć Pull Requesty do `main`!
 


### PR DESCRIPTION
Aktualizacja dokumentacji po włączeniu branch protection dla 'main'.

- Branch protection zostało włączone dla 'main'
- Wymagane PR przed merge (nawet dla właściciela)
- Wymagana 1 recenzja
- Force push i usuwanie brancha zabronione
- Zaktualizowano status w dokumentacji

**To jest pierwszy PR po włączeniu branch protection - demonstracja działania!**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update documentation to mark `main` branch protection as active and list enforced rules (reviews, admin enforcement, block force-push/deletion, dismiss stale reviews).
> 
> - **Docs** (`docs/BRANCH_PROTECTION_SETUP.md`):
>   - Mark branch protection for `main` as active and completed.
>   - Add current status section detailing enforced rules:
>     - `Require pull request reviews` (1 review)
>     - `Enforce for admins`
>     - `Block force pushes`
>     - `Block deletions`
>     - `Dismiss stale reviews`
>   - Note that even the owner must use PRs to `main`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a89bcb47dd13c5ddd5ae5be4f24f3b5081b9ac31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->